### PR TITLE
Add notes about compiling on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ badsectors/build
 *.elf
 *.smdh
 *.3dsx
+
+# IntelliJ Clion IDEA files
+.idea/
+CMakeLists.txt
+cmake-build-debug/

--- a/COMPILE.md
+++ b/COMPILE.md
@@ -1,0 +1,118 @@
+### Unix
+First you will need [devkitArm] which can be obtained with
+
+```bash
+wget http://sourceforge.net/projects/devkitpro/files/Automated%20Installer/devkitARMupdate.pl
+chmod +x devkitARMupdate.pl
+sudo ./devkitARMupdate.pl /opt/devkitPro
+echo "export DEVKITPRO=/opt/devkitPro" >> ~/.bashrc
+echo "export DEVKITARM=\$DEVKITPRO/devkitARM" >> ~/.bashrc
+echo "export PATH=\$PATH:\$DEVKITARM/bin" >> ~/.bashrc
+source ~/.bashrc
+```
+
+Please note: The env variables need to be available from sudo
+
+```bash
+Defaults env_keep += "DEVKITPRO DEVKITARM"
+```
+
+The following can be installed with [3ds_portlibs]:
+* libpng 1.6.19
+* libJPEGTurbo 1.5.1
+* freetype 2.7.1
+
+The following will need to be manually installed:
+* [sf2dlib]
+* [sftdlib]
+* [sfillib]
+
+When cloning the repo make sure to use `git clone --recursive` in order to also get buildtools and the other dependencies.
+
+In case you're compiling for *hax-based homebrew launchers ensure you also create an xml file with 
+`<targets selectable="true"></targets>` and put it along side the `.3dsx` file with matching names.
+
+### Windows
+Install the following using [devkitProUpdater]:
+* [devkitArm] r46
+* [libctru] 1.2.1
+* [citro3D] (commit 3ae31ad)
+
+**Note**: It is suggested to install dev tools at the root of your disk drive i.e. `C:\Development\devkitPro`
+
+Once installed, make sure you have access to a C compiler from `cmd`. If you're not sure install [mingw-w64] to 
+`C:\Development\mingw-w64` and then add the path `C:\Development\mingw-w64\mingw32\bin` to your env variables.
+
+Open command prompt as an **administrator** and `cd` into the devkitPro installation folder. Some commands need admin 
+rights to properly install.
+
+Next `git clone` the latest [3ds_portlibs]:
+* zlib
+* libpng 1.6.19
+* libJPEGTurbo 1.5.1
+* freetype 2.7.1
+
+```bash
+git clone https://github.com/devkitPro/3ds_portlibs.git
+cd 3ds_portlibs
+
+make zlib
+make install-zlib
+
+make libpng
+make install libpng
+
+make libjpeg-turbo
+make install libjpeg-turbo
+
+make freetype
+make install freetype
+```
+
+Manually install each of the following into the devkitPro folder:
+* [sf2dlib]
+* [sftdlib]
+* [sfillib]
+
+```bash
+git clone https://github.com/xerpi/sf2dlib.git
+cd sf2dlib/libsf2d
+make
+make install
+
+git clone https://github.com/xerpi/sftdlib.git
+cd sftdlib/libsftd
+make
+make install
+
+git clone https://github.com/xerpi/sfillib.git
+cd sfillib
+make
+make install
+```
+
+Finally, clone this repo recursively and build with
+
+```bash
+git clone --recursive https://github.com/BernardoGiordano/PKSM.git
+cd PKSM
+make
+make install
+```
+
+In case you're compiling for *hax-based homebrew launchers ensure you also create an xml file with 
+`<targets selectable="true"></targets>` and put it along side the `.3dsx` file with matching names.
+
+[//]: # (These are reference links used in the body of this note and get stripped out when the markdown processor does its job. 
+There is no need to format nicely because it shouldn't be seen. 
+Thanks SO - http://stackoverflow.com/questions/4823468/store-comments-in-markdown-syntax)
+
+[3ds_portlibs]: <https://github.com/devkitPro/3ds_portlibs>
+[devkitProUpdater]: <https://sourceforge.net/projects/devkitpro/>
+[devkitArm]: <https://sourceforge.net/projects/devkitpro/files/devkitARM/>
+[citro3D]: <https://sourceforge.net/projects/devkitpro/files/citro3d/>
+[libctru]: <https://sourceforge.net/projects/devkitpro/files/libctru/>
+[mingw-w64]: <https://sourceforge.net/projects/mingw-w64/>
+[sf2dlib]: <https://github.com/xerpi/sf2dlib>
+[sftdlib]: <https://github.com/xerpi/sftdlib>
+[sfillib]: <https://github.com/xerpi/sfillib>

--- a/README.md
+++ b/README.md
@@ -66,22 +66,109 @@ Pull Requests are greatly appreciated. If you're planning to add features that r
 
 ## Compiling
 
-You will need:
+### Unix
+First you will need [devkitArm] which can be obtained with
 
-* devKitArm r46
-* ctrulib 1.2.1
-* citro3D (commit 3ae31ad)
+```bash
+wget http://sourceforge.net/projects/devkitpro/files/Automated%20Installer/devkitARMupdate.pl
+chmod +x devkitARMupdate.pl
+sudo ./devkitARMupdate.pl /opt/devkitPro
+echo "export DEVKITPRO=/opt/devkitPro" >> ~/.bashrc
+echo "export DEVKITARM=\$DEVKITPRO/devkitARM" >> ~/.bashrc
+echo "export PATH=\$PATH:\$DEVKITARM/bin" >> ~/.bashrc
+source ~/.bashrc
+```
+
+Please note: The env variables need to be available from sudo
+
+```bash
+Defaults env_keep += "DEVKITPRO DEVKITARM"
+```
+
+The following can be installed with [3ds_portlibs]:
 * libpng 1.6.19
 * libJPEGTurbo 1.5.1
 * freetype 2.7.1
-* sf2dlib
-* sftdlib
-* sfillib
+
+The following will need to be manually installed:
+* [sf2dlib]
+* [sftdlib]
+* [sfillib]
 
 When cloning the repo make sure to use `git clone --recursive` in order to also get buildtools and the other dependencies.
 
-Lastly in case you're compiling for *hax-based homebrew launchers ensure you also create an xml file with `<targets selectable="true"></targets>` and put it along side the `.3dsx` file with matching names.
+In case you're compiling for *hax-based homebrew launchers ensure you also create an xml file with `<targets selectable="true"></targets>` and put it along side the `.3dsx` file with matching names.
 
+### Windows
+Install the following using [devkitProUpdater]:
+* [devkitArm] r46
+* [libctru] 1.2.1
+* [citro3D] (commit 3ae31ad)
+
+**Note**: It is suggested to install dev tools at the root of your disk drive i.e. `C:\Development\devkitPro`
+
+Once installed, make sure you have access to a C compiler from `cmd`. If you're not sure install [mingw-w64] to 
+`C:\Development\mingw-w64` and then add the path `C:\Development\mingw-w64\mingw32\bin` to your env variables.
+
+Open command prompt as an **administrator** and `cd` into the devkitPro installation folder. Some commands need admin 
+rights to properly install.
+
+Next `git clone` the latest [3ds_portlibs]:
+* zlib
+* libpng 1.6.19
+* libJPEGTurbo 1.5.1
+* freetype 2.7.1
+
+```bash
+git clone https://github.com/devkitPro/3ds_portlibs.git
+cd 3ds_portlibs
+
+make zlib
+make install-zlib
+
+make libpng
+make install libpng
+
+make libjpeg-turbo
+make install libjpeg-turbo
+
+make freetype
+make install freetype
+```
+
+Manually install each of the following into the devkitPro folder:
+* [sf2dlib]
+* [sftdlib]
+* [sfillib]
+
+```bash
+git clone https://github.com/xerpi/sf2dlib.git
+cd sf2dlib/libsf2d
+make
+make install
+
+git clone https://github.com/xerpi/sftdlib.git
+cd sftdlib/libsftd
+make
+make install
+
+git clone https://github.com/xerpi/sfillib.git
+cd sfillib
+make
+make install
+```
+
+Finally, clone this repo recursively and build with
+
+```bash
+git clone --recursive https://github.com/BernardoGiordano/PKSM.git
+cd PKSM
+make
+make install
+```
+
+In case you're compiling for *hax-based homebrew launchers ensure you also create an xml file with 
+`<targets selectable="true"></targets>` and put it along side the `.3dsx` file with matching names.
 ## Screenshots
 
 <img src="assets/page/01.png" width="350"> <img src="assets/page/02.png" width="350">
@@ -126,3 +213,17 @@ Copyright (C) 2016/2017 Bernardo Giordano
 >    You should have received a copy of the GNU General Public License
 >    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 >    See LICENSE for information.
+
+[//]: # (These are reference links used in the body of this note and get stripped out when the markdown processor does its job. 
+There is no need to format nicely because it shouldn't be seen. 
+Thanks SO - http://stackoverflow.com/questions/4823468/store-comments-in-markdown-syntax)
+
+[3ds_portlibs]: <https://github.com/devkitPro/3ds_portlibs>
+[devkitProUpdater]: <https://sourceforge.net/projects/devkitpro/>
+[devkitArm]: <https://sourceforge.net/projects/devkitpro/files/devkitARM/>
+[citro3D]: <https://sourceforge.net/projects/devkitpro/files/citro3d/>
+[libctru]: <https://sourceforge.net/projects/devkitpro/files/libctru/>
+[mingw-w64]: <https://sourceforge.net/projects/mingw-w64/>
+[sf2dlib]: <https://github.com/xerpi/sf2dlib>
+[sftdlib]: <https://github.com/xerpi/sftdlib>
+[sfillib]: <https://github.com/xerpi/sfillib>

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Once installed, make sure you have access to a C compiler from `cmd`. If you're 
 `C:\Development\mingw-w64` and then add the path `C:\Development\mingw-w64\mingw32\bin` to your env variables.
 
 Open command prompt as an **administrator** and `cd` into the devkitPro installation folder. Some commands need admin 
-rights to properly install.
+rights to properly install. Additionally any installed antivirus might block installation files.
 
 Next `git clone` the latest [3ds_portlibs]:
 * zlib
@@ -146,14 +146,14 @@ git clone https://github.com/xerpi/sf2dlib.git
 cd sf2dlib/libsf2d
 make
 make install
-
+cd ../..
 git clone https://github.com/xerpi/sftdlib.git
 cd sftdlib/libsftd
 make
 make install
-
+cd ../..
 git clone https://github.com/xerpi/sfillib.git
-cd sfillib
+cd sfillib/libsfil
 make
 make install
 ```

--- a/README.md
+++ b/README.md
@@ -65,110 +65,24 @@ We'll not reply to issues related to versions of PKSM different from the latest 
 Pull Requests are greatly appreciated. If you're planning to add features that requires a good bunch of work, please tell us before starting, in order to avoid wasting your time if the feature you're planning to add will not be possible to merge.
 
 ## Compiling
+You will need:
 
-### Unix
-First you will need [devkitArm] which can be obtained with
-
-```bash
-wget http://sourceforge.net/projects/devkitpro/files/Automated%20Installer/devkitARMupdate.pl
-chmod +x devkitARMupdate.pl
-sudo ./devkitARMupdate.pl /opt/devkitPro
-echo "export DEVKITPRO=/opt/devkitPro" >> ~/.bashrc
-echo "export DEVKITARM=\$DEVKITPRO/devkitARM" >> ~/.bashrc
-echo "export PATH=\$PATH:\$DEVKITARM/bin" >> ~/.bashrc
-source ~/.bashrc
-```
-
-Please note: The env variables need to be available from sudo
-
-```bash
-Defaults env_keep += "DEVKITPRO DEVKITARM"
-```
-
-The following can be installed with [3ds_portlibs]:
-* libpng 1.6.19
-* libJPEGTurbo 1.5.1
-* freetype 2.7.1
-
-The following will need to be manually installed:
-* [sf2dlib]
-* [sftdlib]
-* [sfillib]
-
-When cloning the repo make sure to use `git clone --recursive` in order to also get buildtools and the other dependencies.
-
-In case you're compiling for *hax-based homebrew launchers ensure you also create an xml file with `<targets selectable="true"></targets>` and put it along side the `.3dsx` file with matching names.
-
-### Windows
-Install the following using [devkitProUpdater]:
-* [devkitArm] r46
+* [devKitArm] r46
 * [libctru] 1.2.1
 * [citro3D] (commit 3ae31ad)
 
-**Note**: It is suggested to install dev tools at the root of your disk drive i.e. `C:\Development\devkitPro`
-
-Once installed, make sure you have access to a C compiler from `cmd`. If you're not sure install [mingw-w64] to 
-`C:\Development\mingw-w64` and then add the path `C:\Development\mingw-w64\mingw32\bin` to your env variables.
-
-Open command prompt as an **administrator** and `cd` into the devkitPro installation folder. Some commands need admin 
-rights to properly install. Additionally any installed antivirus might block installation files.
-
-Next `git clone` the latest [3ds_portlibs]:
-* zlib
+The following from [3ds_portlibs]:
 * libpng 1.6.19
 * libJPEGTurbo 1.5.1
 * freetype 2.7.1
 
-```bash
-git clone https://github.com/devkitPro/3ds_portlibs.git
-cd 3ds_portlibs
-
-make zlib
-make install-zlib
-
-make libpng
-make install libpng
-
-make libjpeg-turbo
-make install libjpeg-turbo
-
-make freetype
-make install freetype
-```
-
-Manually install each of the following into the devkitPro folder:
+The following from github:
 * [sf2dlib]
 * [sftdlib]
 * [sfillib]
 
-```bash
-git clone https://github.com/xerpi/sf2dlib.git
-cd sf2dlib/libsf2d
-make
-make install
-cd ../..
-git clone https://github.com/xerpi/sftdlib.git
-cd sftdlib/libsftd
-make
-make install
-cd ../..
-git clone https://github.com/xerpi/sfillib.git
-cd sfillib/libsfil
-make
-make install
-```
+Check out `COMPILE.md` for more details.
 
-Finally, clone this repo recursively and build with
-
-```bash
-git clone --recursive https://github.com/BernardoGiordano/PKSM.git
-cd PKSM
-make
-make install
-```
-
-In case you're compiling for *hax-based homebrew launchers ensure you also create an xml file with 
-`<targets selectable="true"></targets>` and put it along side the `.3dsx` file with matching names.
 ## Screenshots
 
 <img src="assets/page/01.png" width="350"> <img src="assets/page/02.png" width="350">


### PR DESCRIPTION
Tested on Windows 7 and 10. Also tested to work with IntelliJ's Clion IDEA using 

CMakeLists.txt
```
cmake_minimum_required(VERSION 3.7)
project(PKSM)

set(CMAKE_CXX_STANDARD 11)

set(SOURCE_FILES
        extrastorage/badsectors/source/main.c
        source/memecrypto/source/aes.c
        source/memecrypto/source/aes.h
        source/memecrypto/source/memecrypto.c
        source/memecrypto/source/memecrypto.h
        source/memecrypto/source/mini-gmp.c
        source/memecrypto/source/mini-gmp.h
        source/memecrypto/source/rsa.c
        source/memecrypto/source/rsa.h
        source/memecrypto/source/sha1.c
        source/memecrypto/source/sha1.h
        source/bank.c
        source/bank.h
        source/common.h
        source/database.c
        source/database.h
        source/dex.c
        source/dex.h
        source/editor.c
        source/editor.h
        source/files.c
        source/files.h
        source/fill.c
        source/fill.h
        source/fx.c
        source/fx.h
        source/graphic.c
        source/graphic.h
        source/hex.c
        source/hex.h
        source/hid.c
        source/hid.h
        source/http.c
        source/http.h
        source/i18n.c
        source/i18n.h
        source/main.c
        source/pkx.c
        source/pkx.h
        source/save.c
        source/save.h
        source/sha256.c
        source/sha256.h
        source/socket.c
        source/socket.h
        source/spi.c
        source/spi.h
        source/util.c
        source/util.h
        source/wcx.c
        source/wcx.h)

add_executable(PKSM ${SOURCE_FILES})

include_directories(C:/Development/devkitPro/devkitARM/include/)
include_directories(C:/Development/devkitPro/devkitARM/arm-none-eabi/include)
include_directories(C:/Development/devkitPro/libctru/include)
include_directories(C:/Development/devkitPro/libjpeg-turbo64/include)
include_directories(C:/Development/devkitPro/portlibs/armv6k/include)
include_directories(C:/Development/devkitPro/portlibs/armv6k/freetype2)
include_directories(C:/Development/devkitPro/portlibs/armv6k/libpng16)
include_directories(C:/Development/devkitPro/sf2dlib/libsf2d/include)
include_directories(C:/Development/devkitPro/sfillib/libsfil/include)
include_directories(C:/Development/devkitPro/sftdlib/libsftd/include)
```

It stills uses the MakeFile to compile but the CMake file lets the the IDE to provides great code coverage, auto completion, refactoring etc.