### PR TITLE
added national dex number to info view

### DIFF
--- a/source/graphic.c
+++ b/source/graphic.c
@@ -1602,6 +1602,10 @@ void printPKBank(u8* bankbuf, u8* mainbuf, u8* wirelessBuffer, u8* pkmnbuf, int 
 				pkx_get_nickname(pkmn, nick);
 				pp2d_draw_wtext(273, 69, FONT_SIZE_12, FONT_SIZE_12, WHITE, (wchar_t*)nick);
 				
+				wchar_t national_id[8];
+				swprintf(national_id, 8, L"%d", pkx_get_species(pkmn));
+				pp2d_draw_wtext(273, 86, FONT_SIZE_12, FONT_SIZE_12, WHITE, national_id);
+				
 				wchar_t level[8];
 				swprintf(level, 8, i18n(S_GRAPHIC_PKBANK_LV_PKMN), pkx_get_level(pkmn));
 				float width = pp2d_get_wtext_width(level, FONT_SIZE_12, FONT_SIZE_12);


### PR DESCRIPTION
Just a simple fix to add national dex number below name (and to left of level) in the small detail view.
This makes it easier to manually sort by ID since there was no easy way to see national ID before.