### PR TITLE
Fix deadlocks when compiling PKSM with latest versions of its dependancies

### DIFF
--- a/3ds/source/app.cpp
+++ b/3ds/source/app.cpp
@@ -926,6 +926,8 @@ Result App::init(const std::string& execPath)
         return consoleDisplayError("Initializing network connection failed.", -1);
     }
 
+    // link3dsStdio();
+
     if (R_FAILED(res = downloadAdditionalAssets()))
     {
         return consoleDisplayError("Additional assets download failed.\n\nAlways make sure you're "

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ export PKSM_AUTHOR		:=	FlagBrew
 
 export VERSION_MAJOR	:=	10
 export VERSION_MINOR	:=	1
-export VERSION_MICRO	:=	3
+export VERSION_MICRO	:=	4
 GIT_REV					:=	$(shell git rev-parse --short HEAD)
 OLD_INFO				:=	$(shell if [ -e appinfo.hash ]; then cat appinfo.hash; fi)
 NOW_INFO				:=	$(PKSM_TITLE) $(PKSM_DESCRIPTION) $(PKSM_AUTHOR) $(VERSION_MAJOR) $(VERSION_MINOR) $(VERSION_MICRO) $(GIT_REV)

--- a/common/source/CloudAccess.cpp
+++ b/common/source/CloudAccess.cpp
@@ -298,7 +298,13 @@ std::unique_ptr<pksm::PKX> CloudAccess::fetchPkm(size_t slot) const
 
 std::optional<int> CloudAccess::nextPage()
 {
-    next->available.wait(false);
+    // next->available.wait(false);
+    while (!next->available.load())
+    {
+        static constexpr timespec sleepTime = {0, 1000000}; // 1 ms
+        nanosleep(&sleepTime, nullptr);
+    }
+
     if (!next->data || next->data->is_discarded())
     {
         isGood = false;
@@ -326,7 +332,13 @@ std::optional<int> CloudAccess::nextPage()
 
 std::optional<int> CloudAccess::prevPage()
 {
-    prev->available.wait(false);
+    // prev->available.wait(false);
+    while (!prev->available.load())
+    {
+        static constexpr timespec sleepTime = {0, 1000000}; // 1 ms
+        nanosleep(&sleepTime, nullptr);
+    }
+    
     if (!prev->data || prev->data->is_discarded())
     {
         isGood = false;

--- a/common/source/GroupCloudAccess.cpp
+++ b/common/source/GroupCloudAccess.cpp
@@ -239,7 +239,13 @@ std::pair<std::string, std::string> GroupCloudAccess::makeURL(
 
 std::optional<int> GroupCloudAccess::nextPage()
 {
-    next->available.wait(false);
+    // next->available.wait(false);
+    while (!next->available.load())
+    {
+        static constexpr timespec sleepTime = {0, 1000000}; // 1 ms
+        nanosleep(&sleepTime, nullptr);
+    }
+
     if (!next->data || next->data->is_discarded())
     {
         isGood = false;
@@ -267,7 +273,13 @@ std::optional<int> GroupCloudAccess::nextPage()
 
 std::optional<int> GroupCloudAccess::prevPage()
 {
-    prev->available.wait(false);
+    // prev->available.wait(false);
+    while (!prev->available.load())
+    {
+        static constexpr timespec sleepTime = {0, 1000000}; // 1 ms
+        nanosleep(&sleepTime, nullptr);
+    }
+
     if (!prev->data || prev->data->is_discarded())
     {
         isGood = false;


### PR DESCRIPTION
This fixes are needed to fix a deadlock issue occurring when compiling PKSM using the latest versions of libraries. The issue doesn't occur if compiled with old versions of its dependencies (for example, 2023 versions of them). Attached below is the dependency list for both cases.

## Output of `dkp-pacman -Sl` on the system with old dependencies, which works without this pr

```
dkp-libs 3ds-bzip2 1.0.8-1 [installed]
dkp-libs 3ds-cmake 1.5.1-1 [installed]
dkp-libs 3ds-curl 7.69.1-3 [installed]
dkp-libs 3ds-examples 20230610-1 [installed]
dkp-libs 3ds-mbedtls 2.28.3-1 [installed]
dkp-libs 3ds-mpg123 1.31.3-2 [installed]
dkp-libs 3ds-pkg-config 0.28-5 [installed]
dkp-libs 3ds-zlib 1.2.13-1 [installed]
dkp-libs citro2d 1.6.0-1 [installed]
dkp-libs citro3d 1.7.0-1 [installed]
dkp-libs devkitarm-cmake 1.2.1-1 [installed]
dkp-libs devkitarm-crtls 1.2.2-1 [installed]
dkp-libs devkitarm-rules 1.5.1-1 [installed]
dkp-libs dkp-cmake-common-utils 1.5.1-1 [installed]
dkp-libs libctru 2.2.2-1 [installed]
dkp-linux 3dslink 0.6.1-1 [installed]
dkp-linux 3dstools 1.3.0-1 [installed]
dkp-linux devkit-env 1.0.1-2 [installed]
dkp-linux devkitARM-gdb 13.2-1 [installed]
dkp-linux devkitpro-keyring 20180316-1 [installed]
dkp-linux general-tools 1.4.4-1 [installed]
dkp-linux pacman 6.0.2-6 [installed]
dkp-linux picasso 2.7.1-2 [installed]
dkp-linux tex3ds 2.3.0-1 [installed]

```

## Output of `dkp-pacman -Sl` on the system with newer dependencies, which doesn't work without this pr

```
dkp-libs 3ds-bzip2 1.0.8-1 [installed]
dkp-libs 3ds-cmake 1.5.1-1 [installed]
dkp-libs 3ds-curl 8.4.0-1 [installed]
dkp-libs 3ds-examples 20240917-1 [installed]
dkp-libs 3ds-mbedtls 2.28.8-1 [installed]
dkp-libs 3ds-mpg123 1.31.3-3 [installed]
dkp-libs 3ds-pkg-config 0.28-5 [installed]
dkp-libs 3ds-zlib 1.3-1 [installed]
dkp-libs catnip 0.1.0-1 [installed]
dkp-libs citro2d 1.6.0-1 [installed]
dkp-libs citro3d 1.7.1-2 [installed]
dkp-libs devkitarm-cmake 1.2.2-1 [installed]
dkp-libs devkitarm-crtls 1.2.6-1 [installed]
dkp-libs devkitarm-rules 1.6.0-4 [installed]
dkp-libs dkp-cmake-common-utils 1.5.2-1 [installed]
dkp-libs libctru 2.4.1-1 [installed]
dkp-linux 3dslink 0.6.3-1 [installed]
dkp-linux 3dstools 1.3.1-3 [installed]
dkp-linux devkit-env 1.0.1-2 [installed]
dkp-linux devkitARM r65-1 [installed]
dkp-linux devkitARM-gdb 14.1-2 [installed]
dkp-linux devkitpro-keyring 20241017-2 [installed]
dkp-linux general-tools 1.4.4-1 [installed]
dkp-linux pacman 6.0.2-6 [installed]
dkp-linux picasso 2.7.2-3 [installed]
dkp-linux tex3ds 2.3.0-4 [installed]
```
