### PR TITLE
Reduce startup time by 63% 

### DIFF
--- a/3ds/Makefile
+++ b/3ds/Makefile
@@ -219,7 +219,7 @@ endif
 export T3XFILES		:=	$(GFXFILES:.t3s=.t3x)
 export ROMFS_FONTFILES	:=	$(patsubst %.ttf, $(GFXBUILD)/%.bcfnt, $(FONTFILES))
 
-export ROMFS_GFXFILES	:=	$(addprefix $(ROMFS)/gfx/,$(addsuffix .bz2, $(notdir $(T3XFILES) $(ROMFS_FONTFILES))))
+export ROMFS_GFXFILES	:=	$(addprefix $(ROMFS)/gfx/,$(notdir $(T3XFILES) $(ROMFS_FONTFILES)))
 
 export OFILES_SOURCES 	:=	$(CPPFILES:.cpp=.o) $(CFILES:.c=.o) $(SFILES:.s=.o)
 
@@ -322,7 +322,7 @@ clean:
 	@rm -fr $(OUT_DEBUG)
 	@rm -fr $(BUILD_DEBUG)
 	@rm -fr $(GFXBUILD)
-	@rm -fr $(ROMFS)/gfx/*.bz2
+	@rm -fr $(ROMFS)/gfx/*
 #---------------------------------------------------------------------------------
 clean-deps:
 	@echo clean-deps ...
@@ -395,10 +395,10 @@ $(GFXBUILD)/%.t3x	$(BUILD)/%.h	:	%.t3s | directories
 	@tex3ds -i $< -H $(BUILD)/$*.h -d $(DEPSDIR)/$*.d -o $@
 
 #---------------------------------------------------------------------------------
-$(ROMFS)/gfx/%.bz2 : $(GFXBUILD)/% | directories
+$(ROMFS)/gfx/% : $(GFXBUILD)/% | directories
 #---------------------------------------------------------------------------------
 	@echo $(notdir $<)
-	@bzip2 -kf --best $< -c > $@
+	@cp $< $@
 
 else
 

--- a/3ds/source/app.cpp
+++ b/3ds/source/app.cpp
@@ -52,7 +52,7 @@
 #include <malloc.h>
 #include <stdio.h>
 #include <sys/stat.h>
-#include <chrono>
+// #include <chrono>
 
 namespace
 {
@@ -565,7 +565,7 @@ namespace
 
 Result App::init(const std::string& execPath)
 {
-    auto start = std::chrono::high_resolution_clock::now();
+    // auto start = std::chrono::high_resolution_clock::now();
 
     Result res;
 
@@ -634,7 +634,7 @@ Result App::init(const std::string& execPath)
         return consoleDisplayError("Initializing network connection failed.", -1);
     }
 
-    link3dsStdio();
+    // link3dsStdio();
 
     if (R_FAILED(res = downloadAdditionalAssets()))
     {
@@ -692,8 +692,8 @@ Result App::init(const std::string& execPath)
     // uncomment when needing to debug with GDB
     // consoleDebugInit(debugDevice_SVC);
 
-    auto end = std::chrono::high_resolution_clock::now();
-    printf("Startup completed in: %sus\n", std::to_string(std::chrono::duration_cast<std::chrono::microseconds>(end - start).count()).c_str());
+    // auto end = std::chrono::high_resolution_clock::now();
+    // printf("Startup completed in: %sus\n", std::to_string(std::chrono::duration_cast<std::chrono::microseconds>(end - start).count()).c_str());
     return 0;
 }
 

--- a/3ds/source/app.cpp
+++ b/3ds/source/app.cpp
@@ -52,6 +52,7 @@
 #include <malloc.h>
 #include <stdio.h>
 #include <sys/stat.h>
+#include <chrono>
 
 namespace
 {
@@ -564,6 +565,8 @@ namespace
 
 Result App::init(const std::string& execPath)
 {
+    auto start = std::chrono::high_resolution_clock::now();
+
     Result res;
 
     hidInit();
@@ -631,7 +634,7 @@ Result App::init(const std::string& execPath)
         return consoleDisplayError("Initializing network connection failed.", -1);
     }
 
-    // link3dsStdio();
+    link3dsStdio();
 
     if (R_FAILED(res = downloadAdditionalAssets()))
     {
@@ -689,6 +692,8 @@ Result App::init(const std::string& execPath)
     // uncomment when needing to debug with GDB
     // consoleDebugInit(debugDevice_SVC);
 
+    auto end = std::chrono::high_resolution_clock::now();
+    printf("Startup completed in: %sus\n", std::to_string(std::chrono::duration_cast<std::chrono::microseconds>(end - start).count()).c_str());
     return 0;
 }
 

--- a/3ds/source/gui/gui.cpp
+++ b/3ds/source/gui/gui.cpp
@@ -965,26 +965,11 @@ Result Gui::init(void)
     g_renderTargetTop    = C2D_CreateScreenTarget(GFX_TOP, GFX_LEFT);
     g_renderTargetBottom = C2D_CreateScreenTarget(GFX_BOTTOM, GFX_LEFT);
 
-    std::vector<u8> loadData;
-    FILE* file = fopen("romfs:/gfx/ui_sheet.t3x.bz2", "rb");
-    int error  = BZ2::decompress(file, loadData);
-    fclose(file);
-    if (error != BZ_OK)
-    {
-        return error;
-    }
-    spritesheet_ui    = C2D_SpriteSheetLoadFromMem(loadData.data(), loadData.size());
+    spritesheet_ui    = C2D_SpriteSheetLoad("romfs:/gfx/ui_sheet.t3x");
     spritesheet_pkm   = C2D_SpriteSheetLoad("/3ds/PKSM/assets/pkm_spritesheet.t3x");
     spritesheet_types = C2D_SpriteSheetLoad("/3ds/PKSM/assets/types_spritesheet.t3x");
 
-    file  = fopen("romfs:/gfx/pksm.bcfnt.bz2", "rb");
-    error = BZ2::decompress(file, loadData);
-    fclose(file);
-    if (error != BZ_OK)
-    {
-        return error;
-    }
-    fonts.emplace_back(C2D_FontLoadFromMem(loadData.data(), loadData.size()));
+    fonts.emplace_back(C2D_FontLoad("romfs:/gfx/pksm.bcfnt"));
     fonts.emplace_back(C2D_FontLoadSystem(CFG_REGION_USA));
     fonts.emplace_back(C2D_FontLoadSystem(CFG_REGION_KOR));
     fonts.emplace_back(C2D_FontLoadSystem(CFG_REGION_CHN));

--- a/3ds/source/gui/gui.cpp
+++ b/3ds/source/gui/gui.cpp
@@ -996,9 +996,6 @@ namespace {
             CFG_REGION_KOR,
             CFG_REGION_USA
         };
-
-        // remove the current region
-        regionsToLoad.erase(std::remove(regionsToLoad.begin(), regionsToLoad.end(), currentRegion), regionsToLoad.end());
         
         for (auto region : regionsToLoad) {
             if (region != currentRegion) {

--- a/3ds/source/gui/gui.cpp
+++ b/3ds/source/gui/gui.cpp
@@ -1010,6 +1010,14 @@ namespace {
             }
         }
         
+        // Create a new TextBuffer with all fonts
+        {
+            std::lock_guard<std::mutex> lock(fontMutex);
+            TextParse::TextBuf* oldBuffer = textBuffer;
+            textBuffer = new TextParse::TextBuf(8192, fonts);
+            delete oldBuffer;
+        }
+        
         fontsLoaded = true;
     }
 }

--- a/3ds/source/gui/gui.cpp
+++ b/3ds/source/gui/gui.cpp
@@ -1003,16 +1003,9 @@ namespace {
                 if (font) {
                     std::lock_guard<std::mutex> lock(fontMutex);
                     fonts.emplace_back(font);
+                    textBuffer->addFont(font);
                 }
             }
-        }
-        
-        // Create a new TextBuffer with all fonts
-        {
-            std::lock_guard<std::mutex> lock(fontMutex);
-            TextParse::TextBuf* oldBuffer = textBuffer;
-            textBuffer = new TextParse::TextBuf(8192, fonts);
-            delete oldBuffer;
         }
         
         fontsLoaded = true;


### PR DESCRIPTION
This PR allows an average startup speed increase from 27s to 10s by:
- loading uncompressed spritesheets and font into memory
- lazyloading system fonts loading