### PR TITLE
Cloud PC box navigation QoL

### DIFF
--- a/3ds/include/gui/screen/CloudScreen.hpp
+++ b/3ds/include/gui/screen/CloudScreen.hpp
@@ -54,6 +54,8 @@ private:
     bool nextBox(bool forceBottom = false);
     bool prevBoxTop();
     bool nextBoxTop();
+    bool jumpBoxTopBy(int delta);
+    bool jumpBoxTop();
     bool clickBottomIndex(int index);
     // Clones from storage (bottom), clones and increments download counter (top), places in storage
     // (bottom), or uploads (top)
@@ -70,8 +72,10 @@ private:
     std::shared_ptr<pksm::PKFilter> filter;
     int cursorIndex        = 0;
     int storageBox         = 0;
+    int pendingPageJumpFrames = 0;
     bool justSwitched      = true;
     bool cloudChosen       = false;
+    bool pendingPageJump   = false;
     std::string websiteURL = "";
 };
 

--- a/3ds/include/gui/screen/GroupCloudScreen.hpp
+++ b/3ds/include/gui/screen/GroupCloudScreen.hpp
@@ -53,6 +53,8 @@ private:
     bool nextBox(bool forceBottom = false);
     bool prevBoxTop();
     bool nextBoxTop();
+    bool jumpBoxTopBy(int delta);
+    bool jumpBoxTop();
     bool clickBottomIndex(int index);
 
     void pickup();
@@ -72,8 +74,10 @@ private:
     GroupCloudAccess access;
     int cursorIndex        = 0;
     int storageBox         = 0;
+    int pendingPageJumpFrames = 0;
     bool justSwitched      = true;
     bool cloudChosen       = false;
+    bool pendingPageJump   = false;
     std::string websiteURL = "";
 };
 

--- a/3ds/source/Configuration.cpp
+++ b/3ds/source/Configuration.cpp
@@ -260,6 +260,10 @@ Configuration::Configuration()
                 (*mJson)["titles"][std::to_string((u32)pksm::GameVersion::SW)] = "0x800";
                 (*mJson)["titles"][std::to_string((u32)pksm::GameVersion::SH)] = "0x900";
             }
+            if ((*mJson)["version"].get<int>() < 13)
+            {
+                (*mJson)["cloudPageJump"] = 1;
+            }
 
             (*mJson)["version"] = CURRENT_VERSION;
             save();
@@ -279,6 +283,7 @@ Configuration::Configuration()
             !(mJson->contains("showBackups") && (*mJson)["showBackups"].is_boolean()) ||
             !(mJson->contains("apiUrl") && (*mJson)["apiUrl"].is_string()) ||
             !(mJson->contains("autoUpdate") && (*mJson)["autoUpdate"].is_boolean()) ||
+            !(mJson->contains("cloudPageJump") && (*mJson)["cloudPageJump"].is_number_integer()) ||
             !(mJson->contains("titles") && (*mJson)["titles"].is_object()) ||
             !((*mJson)["defaults"].contains("date") && (*mJson)["defaults"]["date"].is_object()) ||
             !((*mJson)["defaults"]["date"].contains("day") && (*mJson)["defaults"]["date"]["day"].is_number_integer()) ||
@@ -334,6 +339,12 @@ Configuration::Configuration()
                     (*mJson)["language"]);
                 return;
             }
+        }
+
+        if ((*mJson)["cloudPageJump"].get<int>() < 1)
+        {
+            (*mJson)["cloudPageJump"] = 1;
+            save();
         }
     }
 }
@@ -478,6 +489,12 @@ bool Configuration::autoUpdate(void) const
     return (*mJson)["autoUpdate"];
 }
 
+int Configuration::cloudPageJump(void) const
+{
+    int value = (*mJson)["cloudPageJump"];
+    return value > 0 ? value : 1;
+}
+
 std::vector<std::string> Configuration::extraSaves(const std::string& id) const
 {
     if ((*mJson)["extraSaves"].count(id) > 0)
@@ -561,6 +578,11 @@ void Configuration::apiUrl(const std::string& value)
 void Configuration::autoUpdate(bool value)
 {
     (*mJson)["autoUpdate"] = value;
+}
+
+void Configuration::cloudPageJump(int value)
+{
+    (*mJson)["cloudPageJump"] = value > 0 ? value : 1;
 }
 
 void Configuration::extraSaves(const std::string& id, const std::vector<std::string>& value)

--- a/3ds/source/gui/gui.cpp
+++ b/3ds/source/gui/gui.cpp
@@ -1068,6 +1068,7 @@ void Gui::frameClean()
 void Gui::mainLoop(void)
 {
     Sound::start();
+    int selectHelpFrames = 0;
     while (aptMainLoop() && !shouldExit)
     {
         hidScanInput();
@@ -1078,9 +1079,18 @@ void Gui::mainLoop(void)
 
         u32 kHeld = hidKeysHeld();
 
+        if (kHeld & KEY_SELECT)
+        {
+            selectHelpFrames++;
+        }
+        else
+        {
+            selectHelpFrames = 0;
+        }
+
         magicFun += M_TAU / 360;
 
-        if (kHeld & KEY_SELECT && !screens.top()->getInstructions().empty())
+        if (selectHelpFrames > 15 && !screens.top()->getInstructions().empty())
         {
             target(GFX_TOP);
             screens.top()->doTopDraw();

--- a/3ds/source/gui/screen/CloudScreen.cpp
+++ b/3ds/source/gui/screen/CloudScreen.cpp
@@ -47,12 +47,14 @@
 #include "sav/Sav.hpp"
 #include "utils/format.hpp"
 #include "website.h"
+#include <cstdlib>
 #include <format>
 #include <sys/stat.h>
 
 CloudScreen::CloudScreen(int storageBox, std::shared_ptr<pksm::PKFilter> filter)
     : Screen(i18n::localize("A_PICKUP") + '\n' + i18n::localize("X_SHARE") + '\n' +
              i18n::localize("Y_GROUP_SINGLE") + '\n' + i18n::localize("START_SORT_FILTER") + '\n' +
+             "SELECT: " + i18n::localize("BOX_JUMP") + '\n' +
              i18n::localize("L_BOX_PREV") + '\n' + i18n::localize("R_BOX_NEXT") + '\n' +
              i18n::localize("B_BACK")),
       filter(filter == nullptr ? std::make_shared<pksm::PKFilter>() : filter),
@@ -369,7 +371,29 @@ void CloudScreen::update(touchPosition* touch)
         }
     }
     u32 kDown   = hidKeysDown();
+    u32 kUp     = hidKeysUp();
     u32 kRepeat = hidKeysDownRepeat();
+
+    if (pendingPageJump)
+    {
+        if (hidKeysHeld() & KEY_SELECT)
+        {
+            pendingPageJumpFrames++;
+            if (pendingPageJumpFrames >= 15)
+            {
+                pendingPageJump      = false;
+                pendingPageJumpFrames = 0;
+            }
+            return;
+        }
+
+        pendingPageJump      = false;
+        pendingPageJumpFrames = 0;
+        if ((kUp & KEY_SELECT) && jumpBoxTop())
+        {
+            return;
+        }
+    }
 
     if (kDown & KEY_B)
     {
@@ -398,6 +422,12 @@ void CloudScreen::update(touchPosition* touch)
         std::unique_ptr<Screen> screen = std::make_unique<GroupCloudScreen>(storageBox, filter);
         Gui::screenBack();
         Gui::setScreen(std::move(screen));
+        return;
+    }
+    else if (kDown & KEY_SELECT)
+    {
+        pendingPageJump      = true;
+        pendingPageJumpFrames = 1;
         return;
     }
 
@@ -520,14 +550,16 @@ void CloudScreen::update(touchPosition* touch)
     }
     else if (kRepeat & KEY_ZR)
     {
-        if (nextBoxTop())
+        const int pageJump = Configuration::getInstance().cloudPageJump();
+        if ((pageJump <= 1 ? nextBoxTop() : jumpBoxTopBy(pageJump)))
         {
             return;
         }
     }
     else if (kRepeat & KEY_ZL)
     {
-        if (prevBoxTop())
+        const int pageJump = Configuration::getInstance().cloudPageJump();
+        if ((pageJump <= 1 ? prevBoxTop() : jumpBoxTopBy(-pageJump)))
         {
             return;
         }
@@ -691,6 +723,72 @@ bool CloudScreen::nextBoxTop()
         Gui::screenBack();
         return true;
     }
+    return false;
+}
+
+bool CloudScreen::jumpBoxTopBy(int delta)
+{
+    if (auto err = access.jumpPage(access.page() + delta))
+    {
+        if (*err != 0)
+        {
+            Gui::warn(pksm::format(i18n::localize("GPSS_COMMUNICATION_ERROR"), *err));
+        }
+        else
+        {
+            Gui::warn(i18n::localize("OFFLINE_ERROR"));
+        }
+        Gui::screenBack();
+        return true;
+    }
+    return false;
+}
+
+bool CloudScreen::jumpBoxTop()
+{
+    if (access.pages() <= 1)
+    {
+        cloudChosen = true;
+        return false;
+    }
+
+    SwkbdState state;
+    const std::string hint =
+        i18n::localize("BOX_JUMP") + " 1-" + std::to_string(access.pages());
+    swkbdInit(&state, SWKBD_TYPE_NUMPAD, 2, std::to_string(access.pages()).size());
+    swkbdSetFeatures(&state, SWKBD_FIXED_WIDTH);
+    swkbdSetHintText(&state, hint.c_str());
+    swkbdSetValidation(&state, SWKBD_NOTEMPTY_NOTBLANK, 0, 0);
+
+    char input[12]  = {0};
+    SwkbdButton ret = swkbdInputText(&state, input, sizeof(input));
+    if (ret != SWKBD_BUTTON_CONFIRM)
+    {
+        return false;
+    }
+
+    char* end = nullptr;
+    long page = std::strtol(input, &end, 10);
+    if (end == input || *end != '\0' || page <= 0)
+    {
+        return false;
+    }
+
+    if (auto err = access.jumpPage((int)page))
+    {
+        if (*err != 0)
+        {
+            Gui::warn(pksm::format(i18n::localize("GPSS_COMMUNICATION_ERROR"), *err));
+        }
+        else
+        {
+            Gui::warn(i18n::localize("OFFLINE_ERROR"));
+        }
+        Gui::screenBack();
+        return true;
+    }
+
+    cloudChosen = true;
     return false;
 }
 

--- a/3ds/source/gui/screen/ConfigScreen.cpp
+++ b/3ds/source/gui/screen/ConfigScreen.cpp
@@ -470,7 +470,7 @@ void ConfigScreen::initButtons()
         },
         ui_sheet_button_info_detail_editor_light_idx, "", 0.0f, COLOR_BLACK));
     tabButtons[2].push_back(std::make_unique<ClickButton>(
-        247, 50, 15, 12,
+        247, 48, 15, 12,
         []()
         {
             Configuration::getInstance().transferEdit(!Configuration::getInstance().transferEdit());
@@ -478,7 +478,7 @@ void ConfigScreen::initButtons()
         },
         ui_sheet_button_info_detail_editor_light_idx, "", 0.0f, COLOR_BLACK));
     tabButtons[2].push_back(std::make_unique<ClickButton>(
-        247, 68, 15, 12,
+        247, 64, 15, 12,
         []()
         {
             Configuration::getInstance().writeFileSave(
@@ -487,7 +487,7 @@ void ConfigScreen::initButtons()
         },
         ui_sheet_button_info_detail_editor_light_idx, "", 0.0f, COLOR_BLACK));
     tabButtons[2].push_back(std::make_unique<ClickButton>(
-        247, 86, 15, 12,
+        247, 80, 15, 12,
         []()
         {
             Configuration::getInstance().useSaveInfo(!Configuration::getInstance().useSaveInfo());
@@ -495,7 +495,7 @@ void ConfigScreen::initButtons()
         },
         ui_sheet_button_info_detail_editor_light_idx, "", 0.0f, COLOR_BLACK));
     tabButtons[2].push_back(std::make_unique<ClickButton>(
-        247, 104, 15, 12,
+        247, 96, 15, 12,
         [this]()
         {
             Configuration::getInstance().useExtData(!Configuration::getInstance().useExtData());
@@ -504,7 +504,7 @@ void ConfigScreen::initButtons()
         },
         ui_sheet_button_info_detail_editor_light_idx, "", 0.0f, COLOR_BLACK));
     tabButtons[2].push_back(std::make_unique<ClickButton>(
-        247, 122, 15, 12,
+        247, 112, 15, 12,
         []()
         {
             Configuration::getInstance().randomMusic(!Configuration::getInstance().randomMusic());
@@ -512,7 +512,7 @@ void ConfigScreen::initButtons()
         },
         ui_sheet_button_info_detail_editor_light_idx, "", 0.0f, COLOR_BLACK));
     tabButtons[2].push_back(std::make_unique<ClickButton>(
-        247, 140, 15, 12,
+        247, 128, 15, 12,
         [this]()
         {
             Configuration::getInstance().showBackups(!Configuration::getInstance().showBackups());
@@ -521,11 +521,19 @@ void ConfigScreen::initButtons()
         },
         ui_sheet_button_info_detail_editor_light_idx, "", 0.0f, COLOR_BLACK));
     tabButtons[2].push_back(std::make_unique<ClickButton>(
-        247, 158, 15, 12,
+        247, 144, 15, 12,
         [this]()
         {
             Configuration::getInstance().autoUpdate(!Configuration::getInstance().autoUpdate());
             return true;
+        },
+        ui_sheet_button_info_detail_editor_light_idx, "", 0.0f, COLOR_BLACK));
+    tabButtons[2].push_back(std::make_unique<ClickButton>(
+        247, 160, 15, 12,
+        []()
+        {
+            inputNumber([](int value) { Configuration::getInstance().cloudPageJump(value); }, 4, 9999);
+            return false;
         },
         ui_sheet_button_info_detail_editor_light_idx, "", 0.0f, COLOR_BLACK));
     tabButtons[2].push_back(std::make_unique<ClickButton>(
@@ -537,7 +545,7 @@ void ConfigScreen::initButtons()
         },
         ui_sheet_button_info_detail_editor_light_idx, "", 0.0f, COLOR_BLACK));
     tabButtons[2].push_back(std::make_unique<ClickButton>(
-        247, 194, 15, 12,
+        247, 192, 15, 12,
         [this]()
         {
             addOverlay<TitleIdOverlay>();
@@ -546,7 +554,7 @@ void ConfigScreen::initButtons()
         },
         ui_sheet_button_info_detail_editor_light_idx, "", 0.0f, COLOR_BLACK));
     tabButtons[2].push_back(std::make_unique<ClickButton>(
-        247, 212, 15, 12,
+        247, 208, 15, 12,
         [this]()
         {
             inputApiUrl();
@@ -680,25 +688,27 @@ void ConfigScreen::drawBottom() const
     {
         Gui::text(i18n::localize("CONFIG_BACKUP_SAVE"), 19, 30, FONT_SIZE_12, COLOR_WHITE,
             TextPosX::LEFT, TextPosY::TOP, TextWidthAction::SQUISH_OR_SCROLL, 223);
-        Gui::text(i18n::localize("CONFIG_EDIT_TRANSFERS"), 19, 48, FONT_SIZE_12, COLOR_WHITE,
+        Gui::text(i18n::localize("CONFIG_EDIT_TRANSFERS"), 19, 46, FONT_SIZE_12, COLOR_WHITE,
             TextPosX::LEFT, TextPosY::TOP, TextWidthAction::SQUISH_OR_SCROLL, 223);
-        Gui::text(i18n::localize("CONFIG_BACKUP_INJECTION"), 19, 66, FONT_SIZE_12, COLOR_WHITE,
+        Gui::text(i18n::localize("CONFIG_BACKUP_INJECTION"), 19, 62, FONT_SIZE_12, COLOR_WHITE,
             TextPosX::LEFT, TextPosY::TOP, TextWidthAction::SQUISH_OR_SCROLL, 223);
-        Gui::text(i18n::localize("CONFIG_SAVE_INFO"), 19, 84, FONT_SIZE_12, COLOR_WHITE,
+        Gui::text(i18n::localize("CONFIG_SAVE_INFO"), 19, 78, FONT_SIZE_12, COLOR_WHITE,
             TextPosX::LEFT, TextPosY::TOP, TextWidthAction::SQUISH_OR_SCROLL, 223);
-        Gui::text(i18n::localize("CONFIG_USE_EXTDATA"), 19, 102, FONT_SIZE_12, COLOR_WHITE,
+        Gui::text(i18n::localize("CONFIG_USE_EXTDATA"), 19, 94, FONT_SIZE_12, COLOR_WHITE,
             TextPosX::LEFT, TextPosY::TOP, TextWidthAction::SQUISH_OR_SCROLL, 223);
-        Gui::text(i18n::localize("CONFIG_RANDOM_MUSIC"), 19, 120, FONT_SIZE_12, COLOR_WHITE,
+        Gui::text(i18n::localize("CONFIG_RANDOM_MUSIC"), 19, 110, FONT_SIZE_12, COLOR_WHITE,
             TextPosX::LEFT, TextPosY::TOP, TextWidthAction::SQUISH_OR_SCROLL, 223);
-        Gui::text(i18n::localize("CONFIG_SHOW_BACKUPS"), 19, 138, FONT_SIZE_12, COLOR_WHITE,
+        Gui::text(i18n::localize("CONFIG_SHOW_BACKUPS"), 19, 126, FONT_SIZE_12, COLOR_WHITE,
             TextPosX::LEFT, TextPosY::TOP, TextWidthAction::SQUISH_OR_SCROLL, 223);
-        Gui::text(i18n::localize("CONFIG_AUTO_UPDATE"), 19, 156, FONT_SIZE_12, COLOR_WHITE,
+        Gui::text(i18n::localize("CONFIG_AUTO_UPDATE"), 19, 142, FONT_SIZE_12, COLOR_WHITE,
+            TextPosX::LEFT, TextPosY::TOP, TextWidthAction::SQUISH_OR_SCROLL, 223);
+        Gui::text(i18n::localize("CONFIG_CLOUD_ZLZR_JUMP"), 19, 158, FONT_SIZE_12, COLOR_WHITE,
             TextPosX::LEFT, TextPosY::TOP, TextWidthAction::SQUISH_OR_SCROLL, 223);
         Gui::text(i18n::localize("EXTRA_SAVES"), 19, 174, FONT_SIZE_12, COLOR_WHITE, TextPosX::LEFT,
             TextPosY::TOP, TextWidthAction::SQUISH_OR_SCROLL, 223);
-        Gui::text(i18n::localize("TITLE_IDS"), 19, 192, FONT_SIZE_12, COLOR_WHITE, TextPosX::LEFT,
+        Gui::text(i18n::localize("TITLE_IDS"), 19, 190, FONT_SIZE_12, COLOR_WHITE, TextPosX::LEFT,
             TextPosY::TOP, TextWidthAction::SQUISH_OR_SCROLL, 223);
-        Gui::text(i18n::localize("API_URL"), 19, 210, FONT_SIZE_12, COLOR_WHITE, TextPosX::LEFT,
+        Gui::text(i18n::localize("API_URL"), 19, 206, FONT_SIZE_12, COLOR_WHITE, TextPosX::LEFT,
             TextPosY::TOP);
 
         for (const auto& button : tabButtons[currentTab])
@@ -711,25 +721,27 @@ void ConfigScreen::drawBottom() const
             270, 31, FONT_SIZE_12, COLOR_WHITE, TextPosX::LEFT, TextPosY::TOP);
         Gui::text(Configuration::getInstance().transferEdit() ? i18n::localize("YES")
                                                               : i18n::localize("NO"),
-            270, 49, FONT_SIZE_12, COLOR_WHITE, TextPosX::LEFT, TextPosY::TOP);
+            270, 47, FONT_SIZE_12, COLOR_WHITE, TextPosX::LEFT, TextPosY::TOP);
         Gui::text(Configuration::getInstance().writeFileSave() ? i18n::localize("YES")
                                                                : i18n::localize("NO"),
-            270, 67, FONT_SIZE_12, COLOR_WHITE, TextPosX::LEFT, TextPosY::TOP);
+            270, 63, FONT_SIZE_12, COLOR_WHITE, TextPosX::LEFT, TextPosY::TOP);
         Gui::text(Configuration::getInstance().useSaveInfo() ? i18n::localize("YES")
                                                              : i18n::localize("NO"),
-            270, 85, FONT_SIZE_12, COLOR_WHITE, TextPosX::LEFT, TextPosY::TOP);
+            270, 79, FONT_SIZE_12, COLOR_WHITE, TextPosX::LEFT, TextPosY::TOP);
         Gui::text(Configuration::getInstance().useExtData() ? i18n::localize("YES")
                                                             : i18n::localize("NO"),
-            270, 103, FONT_SIZE_12, COLOR_WHITE, TextPosX::LEFT, TextPosY::TOP);
+            270, 95, FONT_SIZE_12, COLOR_WHITE, TextPosX::LEFT, TextPosY::TOP);
         Gui::text(Configuration::getInstance().randomMusic() ? i18n::localize("YES")
                                                              : i18n::localize("NO"),
-            270, 121, FONT_SIZE_12, COLOR_WHITE, TextPosX::LEFT, TextPosY::TOP);
+            270, 111, FONT_SIZE_12, COLOR_WHITE, TextPosX::LEFT, TextPosY::TOP);
         Gui::text(Configuration::getInstance().showBackups() ? i18n::localize("YES")
                                                              : i18n::localize("NO"),
-            270, 139, FONT_SIZE_12, COLOR_WHITE, TextPosX::LEFT, TextPosY::TOP);
+            270, 127, FONT_SIZE_12, COLOR_WHITE, TextPosX::LEFT, TextPosY::TOP);
         Gui::text(Configuration::getInstance().autoUpdate() ? i18n::localize("YES")
                                                             : i18n::localize("NO"),
-            270, 157, FONT_SIZE_12, COLOR_WHITE, TextPosX::LEFT, TextPosY::TOP);
+            270, 143, FONT_SIZE_12, COLOR_WHITE, TextPosX::LEFT, TextPosY::TOP);
+        Gui::text(std::to_string(Configuration::getInstance().cloudPageJump()), 270, 159,
+            FONT_SIZE_12, COLOR_WHITE, TextPosX::LEFT, TextPosY::TOP);
     }
 }
 

--- a/3ds/source/gui/screen/GroupCloudScreen.cpp
+++ b/3ds/source/gui/screen/GroupCloudScreen.cpp
@@ -46,12 +46,14 @@
 #include "utils/format.hpp"
 #include "website.h"
 #include <algorithm>
+#include <cstdlib>
 #include <format>
 #include <sys/stat.h>
 
 GroupCloudScreen::GroupCloudScreen(int storageBox, std::shared_ptr<pksm::PKFilter> filter)
     : Screen(i18n::localize("A_PICKUP") + '\n' + i18n::localize("X_SHARE") + '\n' +
              i18n::localize("Y_GROUP_SINGLE") + '\n' + i18n::localize("START_FILTER_LEGAL") + '\n' +
+             "SELECT: " + i18n::localize("BOX_JUMP") + '\n' +
              i18n::localize("L_BOX_PREV") + '\n' + i18n::localize("R_BOX_NEXT") + '\n' +
              i18n::localize("B_BACK")),
       filter(filter ? filter : std::make_shared<pksm::PKFilter>()),
@@ -389,7 +391,29 @@ void GroupCloudScreen::update(touchPosition* touch)
         }
     }
     u32 kDown   = hidKeysDown();
+    u32 kUp     = hidKeysUp();
     u32 kRepeat = hidKeysDownRepeat();
+
+    if (pendingPageJump)
+    {
+        if (hidKeysHeld() & KEY_SELECT)
+        {
+            pendingPageJumpFrames++;
+            if (pendingPageJumpFrames >= 15)
+            {
+                pendingPageJump      = false;
+                pendingPageJumpFrames = 0;
+            }
+            return;
+        }
+
+        pendingPageJump      = false;
+        pendingPageJumpFrames = 0;
+        if ((kUp & KEY_SELECT) && jumpBoxTop())
+        {
+            return;
+        }
+    }
 
     if (kDown & KEY_B)
     {
@@ -448,6 +472,12 @@ void GroupCloudScreen::update(touchPosition* touch)
     else if (kDown & KEY_START)
     {
         access.filterLegal(!access.filterLegal());
+    }
+    else if (kDown & KEY_SELECT)
+    {
+        pendingPageJump      = true;
+        pendingPageJumpFrames = 1;
+        return;
     }
 
     if (kRepeat & KEY_LEFT)
@@ -542,14 +572,16 @@ void GroupCloudScreen::update(touchPosition* touch)
     }
     else if (kRepeat & KEY_ZR)
     {
-        if (nextBoxTop())
+        const int pageJump = Configuration::getInstance().cloudPageJump();
+        if ((pageJump <= 1 ? nextBoxTop() : jumpBoxTopBy(pageJump)))
         {
             return;
         }
     }
     else if (kRepeat & KEY_ZL)
     {
-        if (prevBoxTop())
+        const int pageJump = Configuration::getInstance().cloudPageJump();
+        if ((pageJump <= 1 ? prevBoxTop() : jumpBoxTopBy(-pageJump)))
         {
             return;
         }
@@ -694,6 +726,72 @@ bool GroupCloudScreen::nextBoxTop()
         Gui::screenBack();
         return true;
     }
+    return false;
+}
+
+bool GroupCloudScreen::jumpBoxTopBy(int delta)
+{
+    if (auto err = access.jumpPage(access.page() + delta))
+    {
+        if (*err != 0)
+        {
+            Gui::warn(pksm::format(i18n::localize("GPSS_COMMUNICATION_ERROR"), *err));
+        }
+        else
+        {
+            Gui::warn(i18n::localize("OFFLINE_ERROR"));
+        }
+        Gui::screenBack();
+        return true;
+    }
+    return false;
+}
+
+bool GroupCloudScreen::jumpBoxTop()
+{
+    if (access.pages() <= 1)
+    {
+        cloudChosen = true;
+        return false;
+    }
+
+    SwkbdState state;
+    const std::string hint =
+        i18n::localize("BOX_JUMP") + " 1-" + std::to_string(access.pages());
+    swkbdInit(&state, SWKBD_TYPE_NUMPAD, 2, std::to_string(access.pages()).size());
+    swkbdSetFeatures(&state, SWKBD_FIXED_WIDTH);
+    swkbdSetHintText(&state, hint.c_str());
+    swkbdSetValidation(&state, SWKBD_NOTEMPTY_NOTBLANK, 0, 0);
+
+    char input[12]  = {0};
+    SwkbdButton ret = swkbdInputText(&state, input, sizeof(input));
+    if (ret != SWKBD_BUTTON_CONFIRM)
+    {
+        return false;
+    }
+
+    char* end = nullptr;
+    long page = std::strtol(input, &end, 10);
+    if (end == input || *end != '\0' || page <= 0)
+    {
+        return false;
+    }
+
+    if (auto err = access.jumpPage((int)page))
+    {
+        if (*err != 0)
+        {
+            Gui::warn(pksm::format(i18n::localize("GPSS_COMMUNICATION_ERROR"), *err));
+        }
+        else
+        {
+            Gui::warn(i18n::localize("OFFLINE_ERROR"));
+        }
+        Gui::screenBack();
+        return true;
+    }
+
+    cloudChosen = true;
     return false;
 }
 

--- a/assets/gui_strings/chs/config.json
+++ b/assets/gui_strings/chs/config.json
@@ -3,6 +3,7 @@
     "API_HINT": "API Url, MUST END WITH /",
     "API_URL": "Local API URL",
     "CONFIG_AUTO_UPDATE": "自动更新PKSM",
+    "CONFIG_CLOUD_ZLZR_JUMP": "Cloud ZL/ZR jump",
     "CONFIG_BACKUP_INJECTION": "导入神秘卡片前备份",
     "CONFIG_BACKUP_SAVE": "载入时自动备份",
     "CONFIG_EDIT_TRANSFERS": "传输时编辑",

--- a/assets/gui_strings/cht/config.json
+++ b/assets/gui_strings/cht/config.json
@@ -3,6 +3,7 @@
     "API_HINT": "API Url, MUST END WITH /",
     "API_URL": "Local API URL",
     "CONFIG_AUTO_UPDATE": "自动更新PKSM",
+    "CONFIG_CLOUD_ZLZR_JUMP": "Cloud ZL/ZR jump",
     "CONFIG_BACKUP_INJECTION": "导入神秘卡片前备份",
     "CONFIG_BACKUP_SAVE": "载入时自动备份",
     "CONFIG_EDIT_TRANSFERS": "传输时编辑",

--- a/assets/gui_strings/eng/config.json
+++ b/assets/gui_strings/eng/config.json
@@ -3,6 +3,7 @@
     "API_HINT": "API Url, MUST END WITH /",
     "API_URL": "Local API URL",
     "CONFIG_AUTO_UPDATE": "Automatically Update PKSM",
+    "CONFIG_CLOUD_ZLZR_JUMP": "Cloud ZL/ZR jump",
     "CONFIG_BACKUP_INJECTION": "Enable backup injection",
     "CONFIG_BACKUP_SAVE": "Automatically backup on load",
     "CONFIG_EDIT_TRANSFERS": "Edit during transfers",

--- a/assets/gui_strings/fre/config.json
+++ b/assets/gui_strings/fre/config.json
@@ -3,6 +3,7 @@
     "API_HINT": "API Url, MUST END WITH /",
     "API_URL": "Local API URL",
     "CONFIG_AUTO_UPDATE": "Mises à jour automatiques de PKSM",
+    "CONFIG_CLOUD_ZLZR_JUMP": "Saut ZL/ZR du cloud",
     "CONFIG_BACKUP_INJECTION": "Activer l'injection de backups",
     "CONFIG_BACKUP_SAVE": "Archivage auto au lancement",
     "CONFIG_EDIT_TRANSFERS": "Editer pendant les transferts",

--- a/assets/gui_strings/ger/config.json
+++ b/assets/gui_strings/ger/config.json
@@ -3,6 +3,7 @@
     "API_HINT": "API Url, MUST END WITH /",
     "API_URL": "Local API URL",
     "CONFIG_AUTO_UPDATE": "Automatisch PKSM Updaten",
+    "CONFIG_CLOUD_ZLZR_JUMP": "Cloud-ZL/ZR-Sprung",
     "CONFIG_BACKUP_INJECTION": "Aktiviere Backup Injektion",
     "CONFIG_BACKUP_SAVE": "Autom. Backup beim Laden",
     "CONFIG_EDIT_TRANSFERS": "Bearbeiten bei Übertragung",

--- a/assets/gui_strings/ita/config.json
+++ b/assets/gui_strings/ita/config.json
@@ -3,6 +3,7 @@
     "API_HINT": "Indirizzo API, deve terminare con /",
     "API_URL": "Indirizzo locale API",
     "CONFIG_AUTO_UPDATE": "Aggiorna PKSM automaticamente",
+    "CONFIG_CLOUD_ZLZR_JUMP": "Salto cloud ZL/ZR",
     "CONFIG_BACKUP_INJECTION": "Abilita scrittura nei backup",
     "CONFIG_BACKUP_SAVE": "Auto-backup al caricamento",
     "CONFIG_EDIT_TRANSFERS": "Modifica nei trasferimenti",

--- a/assets/gui_strings/jpn/config.json
+++ b/assets/gui_strings/jpn/config.json
@@ -3,6 +3,7 @@
     "API_HINT": "API Url, MUST END WITH /",
     "API_URL": "Local API URL",
     "CONFIG_AUTO_UPDATE": "PKSMを自動アップデートする",
+    "CONFIG_CLOUD_ZLZR_JUMP": "Cloud ZL/ZR jump",
     "CONFIG_BACKUP_INJECTION": "バックアップインジェクションを有効にする",
     "CONFIG_BACKUP_SAVE": "自動的にバックアップを読み込む",
     "CONFIG_EDIT_TRANSFERS": "転送中の変更を有効にする",

--- a/assets/gui_strings/kor/config.json
+++ b/assets/gui_strings/kor/config.json
@@ -3,6 +3,7 @@
     "API_HINT": "API Url, MUST END WITH /",
     "API_URL": "Local API URL",
     "CONFIG_AUTO_UPDATE": "Automatically Update PKSM",
+    "CONFIG_CLOUD_ZLZR_JUMP": "Cloud ZL/ZR jump",
     "CONFIG_BACKUP_INJECTION": "백업 파일 주입 활성화",
     "CONFIG_BACKUP_SAVE": "실행 시 자동으로 백업",
     "CONFIG_EDIT_TRANSFERS": "전송 중 수정하기",

--- a/assets/gui_strings/nl/config.json
+++ b/assets/gui_strings/nl/config.json
@@ -3,6 +3,7 @@
     "API_HINT": "API Url, MUST END WITH /",
     "API_URL": "Local API URL",
     "CONFIG_AUTO_UPDATE": "PKSM automatische updaten",
+    "CONFIG_CLOUD_ZLZR_JUMP": "Cloud ZL/ZR sprong",
     "CONFIG_BACKUP_INJECTION": "Activeer back-up injectie",
     "CONFIG_BACKUP_SAVE": "Automatische back-up bij het laden",
     "CONFIG_EDIT_TRANSFERS": "Bewerk tijdens overdracht",

--- a/assets/gui_strings/pt/config.json
+++ b/assets/gui_strings/pt/config.json
@@ -3,6 +3,7 @@
     "API_HINT": "API Url, MUST END WITH /",
     "API_URL": "Local API URL",
     "CONFIG_AUTO_UPDATE": "Automatically Update PKSM",
+    "CONFIG_CLOUD_ZLZR_JUMP": "Cloud ZL/ZR jump",
     "CONFIG_BACKUP_INJECTION": "Habilitar injeção no backup",
     "CONFIG_BACKUP_SAVE": "Auto-backup ao carregar",
     "CONFIG_EDIT_TRANSFERS": "Editar durante transferir",

--- a/assets/gui_strings/ro/config.json
+++ b/assets/gui_strings/ro/config.json
@@ -3,6 +3,7 @@
     "API_HINT": "API Url, MUST END WITH /",
     "API_URL": "Local API URL",
     "CONFIG_AUTO_UPDATE": "Updatează Automat PKSM",
+    "CONFIG_CLOUD_ZLZR_JUMP": "Cloud ZL/ZR jump",
     "CONFIG_BACKUP_INJECTION": "Permite Injecție Backup",
     "CONFIG_BACKUP_SAVE": "Backup Automat La Încărcare",
     "CONFIG_EDIT_TRANSFERS": "Editează în timpul transferului",

--- a/assets/gui_strings/spa/config.json
+++ b/assets/gui_strings/spa/config.json
@@ -3,6 +3,7 @@
     "API_HINT": "API Url, MUST END WITH /",
     "API_URL": "Local API URL",
     "CONFIG_AUTO_UPDATE": "Actualizar PKSM automáticamente",
+    "CONFIG_CLOUD_ZLZR_JUMP": "Salto cloud ZL/ZR",
     "CONFIG_BACKUP_INJECTION": "Habilitar «backup injection»",
     "CONFIG_BACKUP_SAVE": "Crear copia de seguridad automática",
     "CONFIG_EDIT_TRANSFERS": "Editar durante transferencias",

--- a/assets/romfs/config.json
+++ b/assets/romfs/config.json
@@ -1,5 +1,5 @@
 {
-  "version": 12,
+  "version": 13,
   "language": 2,
   "autoBackup": true,
   "transferEdit": true,
@@ -43,5 +43,6 @@
   "randomMusic": false,
   "showBackups": false,
   "apiUrl": "",
-  "autoUpdate": true
+  "autoUpdate": true,
+  "cloudPageJump": 1
 }

--- a/common/include/CloudAccess.hpp
+++ b/common/include/CloudAccess.hpp
@@ -55,6 +55,7 @@ public:
 
     std::optional<int> nextPage();
     std::optional<int> prevPage();
+    std::optional<int> jumpPage(int page);
 
     void sortType(SortType type)
     {

--- a/common/include/Configuration.hpp
+++ b/common/include/Configuration.hpp
@@ -37,7 +37,7 @@
 class Configuration
 {
 public:
-    static constexpr int CURRENT_VERSION = 12;
+    static constexpr int CURRENT_VERSION = 13;
 
     static Configuration& getInstance(void)
     {
@@ -96,6 +96,8 @@ public:
 
     bool autoUpdate(void) const;
 
+    int cloudPageJump(void) const;
+
     void language(pksm::Language lang);
 
     void autoBackup(bool backup);
@@ -130,6 +132,8 @@ public:
     void apiUrl(const std::string& value);
 
     void autoUpdate(bool value);
+
+    void cloudPageJump(int value);
 
     void save(void);
 

--- a/common/include/GroupCloudAccess.hpp
+++ b/common/include/GroupCloudAccess.hpp
@@ -52,6 +52,7 @@ public:
 
     std::optional<int> nextPage();
     std::optional<int> prevPage();
+    std::optional<int> jumpPage(int page);
 
     bool filterLegal() const { return legal; }
 

--- a/common/source/CloudAccess.cpp
+++ b/common/source/CloudAccess.cpp
@@ -365,6 +365,36 @@ std::optional<int> CloudAccess::prevPage()
     return std::nullopt;
 }
 
+std::optional<int> CloudAccess::jumpPage(int page)
+{
+    if (!good())
+    {
+        return currentPageError();
+    }
+
+    if (page < 1)
+    {
+        page = 1;
+    }
+    else if (page > pages())
+    {
+        page = pages();
+    }
+
+    if (page == pageNumber)
+    {
+        return std::nullopt;
+    }
+
+    pageNumber = page;
+    refreshPages();
+    if (!good())
+    {
+        return currentPageError();
+    }
+    return std::nullopt;
+}
+
 long CloudAccess::pkm(std::unique_ptr<pksm::PKX> mon)
 {
     long ret            = 0;

--- a/common/source/GroupCloudAccess.cpp
+++ b/common/source/GroupCloudAccess.cpp
@@ -307,6 +307,36 @@ std::optional<int> GroupCloudAccess::prevPage()
     return std::nullopt;
 }
 
+std::optional<int> GroupCloudAccess::jumpPage(int page)
+{
+    if (!good())
+    {
+        return currentPageError();
+    }
+
+    if (page < 1)
+    {
+        page = 1;
+    }
+    else if (page > pages())
+    {
+        page = pages();
+    }
+
+    if (page == pageNumber)
+    {
+        return std::nullopt;
+    }
+
+    pageNumber = page;
+    refreshPages();
+    if (!good())
+    {
+        return currentPageError();
+    }
+    return std::nullopt;
+}
+
 int GroupCloudAccess::pages() const
 {
     return (*current->data)["pages"].get<int>();


### PR DESCRIPTION
**__Summary__**

This PR adds a small QoL improvement for navigating large cloud databases.

**__Changes :__**
Keep L/R behavior unchanged (single-page navigation)
Add a configurable cloudPageJump setting for ZL/ZR
Default value is 1, so existing behavior stays the same unless changed
Add a quick page jump via Select (short press opens a numpad on the touchscreen)
Keep long press on Select unchanged (still shows contextual help)
Allow larger page jumps in cloud and group cloud navigation
Expose the setting in the config screen
Add localization entries for the new option

**__Why :__**
When dealing with a large number of cloud pages, moving one page at a time quickly gets slow.

This becomes especially noticeable with bigger libraries, where going through pages manually takes a while.

**__Behavior :__**
L/R still move one page at a time
ZL/ZR use the configured jump value
Default configuration behaves exactly like before
Increasing the jump value allows faster navigation across pages

This is meant as a QoL improvement only.

By default nothing changes, and the new behavior is only used if the user increases the jump value in the misc settings tab.